### PR TITLE
Add theme-color for google chrome on android

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="favicon-128.png" sizes="128x128" />
   <meta name="application-name" content="&nbsp;"/>
+  <meta name="theme-color" content="#432460">
 </head>
 <body class="{{ page.section }}">
   <header class="main" role="banner">


### PR DESCRIPTION
Since Chrome 39 on Android it's possible to style the toolbar with an color. I made it for our site, because on android it's easier to recognize and it's look more :sparkles: .

The Screens were taken in combination with the styling of PR #5 .

.**Before:**
![before_1](https://cloud.githubusercontent.com/assets/886383/15440182/606a1fb8-1ed4-11e6-8506-167fb0840ca8.png)
![before_2](https://cloud.githubusercontent.com/assets/886383/15440183/606aa7e4-1ed4-11e6-8846-4279b882ad43.png)

**After:**
![after_1](https://cloud.githubusercontent.com/assets/886383/15440184/606ef13c-1ed4-11e6-98db-217aea33c194.png)
![after_2](https://cloud.githubusercontent.com/assets/886383/15440185/6070d92a-1ed4-11e6-9481-7826782bcfbb.png)
