### PR TITLE
Use HTTPS for (almost) all outgoing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elixir.Ruhr
 
-Content for http://elixir.ruhr
+Content for https://elixir.ruhr
 
 ## Requirements
 
@@ -12,14 +12,14 @@ Therefor you have to setup it before cloning this repository:
 
 ## Installation
 
-Run the following command in your terminal using [Bundler](http://bundler.io)
+Run the following command in your terminal using [Bundler](https://bundler.io)
 to setup the environment:
 
     $ bundle install
 
 ## Usage
 
-You can preview your changes using the [Jekyll](http://jekyllrb.com) server:
+You can preview your changes using the [Jekyll](https://jekyllrb.com) server:
 
     $ jekyll serve
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <li><h3>Connect</h3></li>
       <li><a href="https://twitter.com/ElixirRuhr">Twitter</a></li>
       <li><a href="https://gitter.im/ElixirRuhr/ElixirRuhr">Gitter chat</a></li>
-      <li><a href="http://www.meetup.com/ElixirRuhr">Meetup</a></li>
+      <li><a href="https://www.meetup.com/ElixirRuhr">Meetup</a></li>
     </ul>
     <ul>
       <li><h3>Contribute</h3></li>

--- a/_includes/locations/das-labor.html
+++ b/_includes/locations/das-labor.html
@@ -2,5 +2,5 @@
 <p>
   The location is well connected to public transport. Please don't plan to
   park directly on the location's backyard as parking space is very limited.
-  For further directions please head to <a href="http://das-labor.org­">das-labor.org­</a>.
+  For further directions please head to <a href="https://das-labor.org">das-labor.org­</a>.
 </p>

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -1,10 +1,10 @@
 <article class="sponsors" id="sponsors">
   <h2>Sponsors</h2>
   <div>
-    <a href="http://9elements.com" target="_blank" title="9elements - mobile and web development" class="nine-elements">
+    <a href="https://9elements.com" target="_blank" title="9elements - mobile and web development" class="nine-elements">
       <img src="/images/sponsors/9elements.png" alt="9elements - mobile and web development"/>
     </a>
-    <a href="http://neopoly.com" target="_blank" title="Neopoly - Online games and services" class="neopoly">
+    <a href="https://neopoly.com" target="_blank" title="Neopoly - Online games and services" class="neopoly">
       <img src="/images/sponsors/neopoly.png" alt="Neopoly - Online games and services"/>
     </a>
   </div>

--- a/_meetups/002-embedded-systems-with-nerves.html
+++ b/_meetups/002-embedded-systems-with-nerves.html
@@ -54,8 +54,8 @@ archived: true
         <li>Slides will follow</li>
       </ul>
       <p class="description">
-      This beginner friendly talk will start with a short introduction about the <a href="https://www.erlang.org/">Erlang</a> and <a href="http://elixir-lang.org/">Elixir</a> toolchain (<a href="http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html">mix</a>, <a href="https://hex.pm/">hex</a> and <a href="https://github.com/elixir-ecto/ecto">ecto</a>).
-        Afterwards Matthias & Farhad will code a small <a href="http://www.phoenixframework.org/">Phoenix</a> app and explain how to extract buisiness related code into a <a href="http://elixir-lang.org/docs/stable/elixir/GenServer.html">GenServer</a>.
+      This beginner friendly talk will start with a short introduction about the <a href="https://www.erlang.org/">Erlang</a> and <a href="https://elixir-lang.org/">Elixir</a> toolchain (<a href="https://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html">mix</a>, <a href="https://hex.pm/">hex</a> and <a href="https://github.com/elixir-ecto/ecto">ecto</a>).
+        Afterwards Matthias & Farhad will code a small <a href="http://phoenixframework.org/">Phoenix</a> app and explain how to extract buisiness related code into a <a href="https://elixir-lang.org/docs/stable/elixir/GenServer.html">GenServer</a>.
       <div class="speaker">
         <div class="avatar">
           <img src="/images/speakers/MatthiasLindhorst.jpg" alt="Avatar of @stressfrei"/>

--- a/coc.html
+++ b/coc.html
@@ -56,7 +56,7 @@ section: coc
 
   <h3>License and attribution</h3>
 
-  <p>Berlin Code of Conduct is distributed under a Creative Commons Attribution-ShareAlike license. It is based on the <a href="http://pdxruby.org/codeofconduct">pdx.rb code of conduct</a>, which is distributed under the same license.</p>
+  <p>Berlin Code of Conduct is distributed under a Creative Commons Attribution-ShareAlike license. It is based on the <a href="https://pdxruby.org/codeofconduct">pdx.rb code of conduct</a>, which is distributed under the same license.</p>
 
   <h3>Community Organizers</h3>
   <ul>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ section: home
 <article class="about">
   <h2>About</h2>
   <p>
-  This meetup aims to build up a community of open minded people in the <a href="https://en.wikipedia.org/wiki/Ruhr">Ruhr</a> area that are interested in the <a href="http://elixir-lang.org">Elixir</a> programming language.
+  This meetup aims to build up a community of open minded people in the <a href="https://en.wikipedia.org/wiki/Ruhr">Ruhr</a> area that are interested in the <a href="https://elixir-lang.org">Elixir</a> programming language.
     </br>
     We are a group of enthusiastic software developers mostly with a strong
     <a href="https://www.ruby-lang.org">Ruby</a> background.

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -38,17 +38,17 @@ section: privacy
     oder Drittanbieter einverstanden.
     <br/>
     Die Nutzungsbedingungen für Google Maps finden Sie unter
-    <a href="http://www.google.com/intl/de_de/help/terms_maps.html">
+    <a href="https://www.google.com/intl/de_de/help/terms_maps.html">
       Nutzungsbedingungen für Google Maps
     </a>.
   </p>
   <p>
     Ausführliche Details finden Sie im Datenschutz-Center von google.de:
-    <a href="http://www.google.de/intl/de/privacy/">
+    <a href="https://www.google.de/intl/de/privacy/">
       Transparenz und Wahlmöglichkeiten
     </a>
     sowie
-    <a href="http://www.google.de/intl/de/privacy/privacy-policy.html">
+    <a href="https://www.google.de/intl/de/privacy/privacy-policy.html">
       Datenschutzbestimmungen
     </a>.
   </p>


### PR DESCRIPTION
Sole exception is http://phoenixframework.org/ which does not have SSL
enabled.